### PR TITLE
fix: disable google translate on index page

### DIFF
--- a/translator/www/index.html
+++ b/translator/www/index.html
@@ -6,6 +6,12 @@
 {% extends "frappe_theme/templates/base.html" %}
 {% block title %}ERPNext Translation Portal{% endblock %}
 
+
+{% block head %}
+	{{ super() }}
+	<meta name="google" content="notranslate">
+{% endblock %}
+
 {% block head_include %}
 	<meta name="description" content="ERPNext translation portal allows users around the world to contribute translations for ERPNext and other Frappe apps" />
 	<meta name="keywords" content="ERP Translation, ERPNext Translation, Frappe Translation, Frappe i18n" />


### PR DESCRIPTION

**Google auto-translate (Chrome):**

![Screenshot 2019-09-15 at 12 59 36 PM](https://user-images.githubusercontent.com/36654812/64918200-b4df5400-d7b8-11e9-9c43-7952f53b6fc3.png)

**Original:**


![Screenshot 2019-09-15 at 12 59 43 PM](https://user-images.githubusercontent.com/36654812/64918201-b4df5400-d7b8-11e9-8135-c3ae58c5d7f9.png)
